### PR TITLE
MONIT-41710: address CVE-2023-44270

### DIFF
--- a/shopping/src/main/ui/package-lock.json
+++ b/shopping/src/main/ui/package-lock.json
@@ -6603,9 +6603,9 @@
           }
         },
         "terser": {
-          "version": "5.19.4",
-          "resolved": "http://build-artifactory.eng.vmware.com/artifactory/api/npm/npm/terser/-/terser-5.19.4.tgz",
-          "integrity": "sha512-6p1DjHeuluwxDXcuT9VR8p64klWJKo1ILiy19s6C9+0Bh2+NWTX6nD9EPppiER4ICkHDVB1RkVpin/YW2nQn/g==",
+          "version": "5.21.0",
+          "resolved": "http://build-artifactory.eng.vmware.com/artifactory/api/npm/npm/terser/-/terser-5.21.0.tgz",
+          "integrity": "sha512-WtnFKrxu9kaoXuiZFSGrcAvvBqAdmKx0SFNmVNYdJamMu9yyN3I/QF0FbH4QcqJQ+y1CJnzxGIKH0cSj+FGYRw==",
           "dev": true,
           "requires": {
             "@jridgewell/source-map": "^0.3.3",
@@ -9188,10 +9188,9 @@
       }
     },
     "nanoid": {
-      "version": "3.3.4",
-      "resolved": "http://build-artifactory.eng.vmware.com/artifactory/api/npm/npm/nanoid/-/nanoid-3.3.4.tgz",
-      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
-      "dev": true
+      "version": "3.3.6",
+      "resolved": "http://build-artifactory.eng.vmware.com/artifactory/api/npm/npm/nanoid/-/nanoid-3.3.6.tgz",
+      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA=="
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -9572,8 +9571,7 @@
     "picocolors": {
       "version": "1.0.0",
       "resolved": "http://build-artifactory.eng.vmware.com/artifactory/api/npm/npm/picocolors/-/picocolors-1.0.0.tgz",
-      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
-      "dev": true
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
     },
     "picomatch": {
       "version": "2.3.1",
@@ -9696,12 +9694,11 @@
       }
     },
     "postcss": {
-      "version": "8.4.21",
-      "resolved": "http://build-artifactory.eng.vmware.com/artifactory/api/npm/npm/postcss/-/postcss-8.4.21.tgz",
-      "integrity": "sha512-tP7u/Sn/dVxK2NnruI4H9BG+x+Wxz6oeZ1cJ8P6G/PZY0IKk4k/63TDsQf2kQq3+qoJeLm2kIBUNlZe3zgb4Zg==",
-      "dev": true,
+      "version": "8.4.31",
+      "resolved": "http://build-artifactory.eng.vmware.com/artifactory/api/npm/npm/postcss/-/postcss-8.4.31.tgz",
+      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
       "requires": {
-        "nanoid": "^3.3.4",
+        "nanoid": "^3.3.6",
         "picocolors": "^1.0.0",
         "source-map-js": "^1.0.2"
       }
@@ -10753,6 +10750,27 @@
         "webpack-dev-server": "^4.6.0",
         "webpack-manifest-plugin": "^4.0.2",
         "workbox-webpack-plugin": "^6.4.1"
+      },
+      "dependencies": {
+        "resolve-url-loader": {
+          "version": "5.0.0",
+          "resolved": "http://build-artifactory.eng.vmware.com/artifactory/api/npm/npm/resolve-url-loader/-/resolve-url-loader-5.0.0.tgz",
+          "integrity": "sha512-uZtduh8/8srhBoMx//5bwqjQ+rfYOUq8zC9NrMUGtjBiGTtFJM42s58/36+hTqeqINcnYe08Nj3LkK9lW4N8Xg==",
+          "dev": true,
+          "requires": {
+            "adjust-sourcemap-loader": "^4.0.0",
+            "convert-source-map": "^1.7.0",
+            "loader-utils": "^2.0.0",
+            "postcss": "^8.2.14",
+            "source-map": "0.6.1"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "http://build-artifactory.eng.vmware.com/artifactory/api/npm/npm/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
       }
     },
     "read-cache": {
@@ -10940,43 +10958,6 @@
       "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
       "dev": true
     },
-    "resolve-url-loader": {
-      "version": "4.0.0",
-      "resolved": "http://build-artifactory.eng.vmware.com/artifactory/api/npm/npm/resolve-url-loader/-/resolve-url-loader-4.0.0.tgz",
-      "integrity": "sha512-05VEMczVREcbtT7Bz+C+96eUO5HDNvdthIiMB34t7FcF8ehcu4wC0sSgPUubs3XW2Q3CNLJk/BJrCU9wVRymiA==",
-      "dev": true,
-      "requires": {
-        "adjust-sourcemap-loader": "^4.0.0",
-        "convert-source-map": "^1.7.0",
-        "loader-utils": "^2.0.0",
-        "postcss": "^7.0.35",
-        "source-map": "0.6.1"
-      },
-      "dependencies": {
-        "picocolors": {
-          "version": "0.2.1",
-          "resolved": "http://build-artifactory.eng.vmware.com/artifactory/api/npm/npm/picocolors/-/picocolors-0.2.1.tgz",
-          "integrity": "sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==",
-          "dev": true
-        },
-        "postcss": {
-          "version": "7.0.39",
-          "resolved": "http://build-artifactory.eng.vmware.com/artifactory/api/npm/npm/postcss/-/postcss-7.0.39.tgz",
-          "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
-          "dev": true,
-          "requires": {
-            "picocolors": "^0.2.1",
-            "source-map": "^0.6.1"
-          }
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "http://build-artifactory.eng.vmware.com/artifactory/api/npm/npm/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        }
-      }
-    },
     "resolve.exports": {
       "version": "1.1.1",
       "resolved": "http://build-artifactory.eng.vmware.com/artifactory/api/npm/npm/resolve.exports/-/resolve.exports-1.1.1.tgz",
@@ -11073,9 +11054,9 @@
           }
         },
         "terser": {
-          "version": "5.19.4",
-          "resolved": "http://build-artifactory.eng.vmware.com/artifactory/api/npm/npm/terser/-/terser-5.19.4.tgz",
-          "integrity": "sha512-6p1DjHeuluwxDXcuT9VR8p64klWJKo1ILiy19s6C9+0Bh2+NWTX6nD9EPppiER4ICkHDVB1RkVpin/YW2nQn/g==",
+          "version": "5.21.0",
+          "resolved": "http://build-artifactory.eng.vmware.com/artifactory/api/npm/npm/terser/-/terser-5.21.0.tgz",
+          "integrity": "sha512-WtnFKrxu9kaoXuiZFSGrcAvvBqAdmKx0SFNmVNYdJamMu9yyN3I/QF0FbH4QcqJQ+y1CJnzxGIKH0cSj+FGYRw==",
           "dev": true,
           "requires": {
             "@jridgewell/source-map": "^0.3.3",
@@ -11426,8 +11407,7 @@
     "source-map-js": {
       "version": "1.0.2",
       "resolved": "http://build-artifactory.eng.vmware.com/artifactory/api/npm/npm/source-map-js/-/source-map-js-1.0.2.tgz",
-      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
-      "dev": true
+      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw=="
     },
     "source-map-loader": {
       "version": "3.0.2",
@@ -11978,9 +11958,9 @@
           "dev": true
         },
         "terser": {
-          "version": "5.19.4",
-          "resolved": "http://build-artifactory.eng.vmware.com/artifactory/api/npm/npm/terser/-/terser-5.19.4.tgz",
-          "integrity": "sha512-6p1DjHeuluwxDXcuT9VR8p64klWJKo1ILiy19s6C9+0Bh2+NWTX6nD9EPppiER4ICkHDVB1RkVpin/YW2nQn/g==",
+          "version": "5.21.0",
+          "resolved": "http://build-artifactory.eng.vmware.com/artifactory/api/npm/npm/terser/-/terser-5.21.0.tgz",
+          "integrity": "sha512-WtnFKrxu9kaoXuiZFSGrcAvvBqAdmKx0SFNmVNYdJamMu9yyN3I/QF0FbH4QcqJQ+y1CJnzxGIKH0cSj+FGYRw==",
           "dev": true,
           "requires": {
             "@jridgewell/source-map": "^0.3.3",

--- a/shopping/src/main/ui/package.json
+++ b/shopping/src/main/ui/package.json
@@ -6,6 +6,7 @@
     "@clr/icons": "^1.1.3",
     "@clr/ui": "^1.1.3",
     "classnames": "^2.2.6",
+    "postcss": "^8.4.31",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "web-vitals": "^2.1.4"
@@ -16,6 +17,7 @@
   },
   "resolutions": {
     "nth-check": "^2.0.1",
+    "resolve-url-loader": "^5.0.0",
     "terser": "^5.14.2",
     "optionator": "^0.9.3"
   },


### PR DESCRIPTION
This bumps all versions of postcss to a minimum of 8.4.31, including as part of a dependency chain.